### PR TITLE
Improve webmanifest

### DIFF
--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -1,6 +1,45 @@
 {
-	"icons": [
-    { "src": "/icons/icon-192.png", "type": "image/png", "sizes": "192x192" },
-    { "src": "/icons/icon-512.png", "type": "image/png", "sizes": "512x512" }
-	]
+    "name": "Flipper Lab",
+    "short_name": "Flipper Lab",
+    "display": "standalone",
+    "start_url": ".",
+    "background_color": "#fff",
+    "related_applications": [
+        {
+            "platform": "play",
+            "id": "com.flipperdevices.app",
+            "url": "https://play.google.com/store/apps/details?id=com.flipperdevices.app"
+        }
+    ],
+    "shortcuts": [
+        {
+            "name": "Files",
+            "url": "/archive"
+        },
+        {
+            "name": "Cli",
+            "url": "/cli"
+        },
+        {
+            "name": "NFC tools",
+            "url": "/nfc-tools"
+        },
+        {
+            "name": "Radio tools",
+            "url": "/pulse-plotter"
+        }
+    ],
+    "theme_color": "#ff8200",
+    "icons": [
+        {
+            "src": "/icons/icon-192.png",
+            "type": "image/png",
+            "sizes": "192x192"
+        },
+        {
+            "src": "/icons/icon-512.png",
+            "type": "image/png",
+            "sizes": "512x512"
+        }
+    ]
 }


### PR DESCRIPTION
Installability on Chrome 111 with #enable-skip-service-worker-check-install-only
This pull doesn't include offline functionality yet.
![Screenshot 2023-02-13 15 00 52](https://user-images.githubusercontent.com/5065094/218532387-94bf5335-e68a-4c81-93e5-1584dd79e474.png)

Installed as app on Chrome OS:
![Screenshot 2023-02-13 15 01 06](https://user-images.githubusercontent.com/5065094/218533275-d6df188b-622a-42be-97b3-b6822377e2a0.png)

![Screenshot 2023-02-13 15 01 13](https://user-images.githubusercontent.com/5065094/218532998-1f076c35-936b-40a0-91f5-aa6b19641dd6.png)
